### PR TITLE
Enh: month in BS for Mangsir

### DIFF
--- a/src/Services/NepaliDate.php
+++ b/src/Services/NepaliDate.php
@@ -112,7 +112,7 @@ class NepaliDate
         5 => 'Bhadra',
         6 => 'Ashoj',
         7 => 'Kartik',
-        8 => 'Manghir',
+        8 => 'Mangsir',
         9 => 'Poush',
         10 => 'Magh',
         11 => 'Falgun',


### PR DESCRIPTION
Popular calendars translate मंसिर to Mangsir, not Manghir.